### PR TITLE
Update tween for the new version

### DIFF
--- a/Modules/Actor.FadeQuad.lua
+++ b/Modules/Actor.FadeQuad.lua
@@ -7,7 +7,7 @@ return function( TweenTime, TweenType, ColorMethod1, ColorMethod2 )
             end,
             OnCommand=function(self)
                 self:diffuse( ColorMethod1 )
-                :tween( TweenTime, TweenType )
+                :tween( TweenTime, TweenType, {0,0,0,0} )
                 :diffuse( ColorMethod2 )
                 :sleep(0.5)
             end


### PR DESCRIPTION
The new version of outfox requires an additional argument to make tween work. So this pull request adds it, while keeping compatibility with the older tween command.