### PR TITLE
Add zh-Hans and zh-Hant translations

### DIFF
--- a/Languages/zh-Hans.ini
+++ b/Languages/zh-Hans.ini
@@ -1,0 +1,287 @@
+[Common]
+WindowTitle=Infinitesimal
+
+[ScreenTitleMenu]
+GameStart=开始
+Edit/Share=编辑
+Profiles=个人资料
+ReportError=汇报 Bug
+%i Songs (%i Groups), %i Courses=%i 首歌曲（%i 专辑），%i 曲组
+
+[ProfileStats]
+No Profile=No Profile
+Level=Level
+
+[ChartInfo]
+By=by
+
+[BasicMode]
+NoSongs=Basic Mode 中没有任何歌曲！\n请重新启动游戏或者添加更多歌曲。
+Double=DOUBLE
+Easy=EASY
+Normal=NORMAL
+Hard=HARD
+Very Hard=VERY HARD
+
+[OptionTitles]
+InfOptionsMain=Infinitesimal 设置
+InfOptionsUI=界面设置
+InfOptionsGameplay=游戏设置
+InfOptionsMisc=其他设置
+
+BasicMode=Basic Mode
+CenterChartList=谱面列表居中
+ChartPreview=谱面预览
+ImagePreviewOnly=仅使用图片预览
+UseSelToPause=使用 Select 按钮暂停
+UseVideoBackground=使用视频背景
+EvalCenter3xExit=按下中间面板三次\n以退出结果界面
+ShowBigBall=显示大的难度图标
+ShowUCSCharts=显示 UCS 谱面
+ShowQuestCharts=显示 Quest 谱面
+ShowHiddenCharts=显示 Hidden 谱面
+AutogenBasicMode=自动生成 Basic Mode
+WrapChartScroll=谱面列表选择切换
+StarField=星空背景
+ScoringSystem=评分系统
+LifePositionBelow=Reverse 生命值条下置
+CarryJudgment=延续判定设置
+ClassicGrades=经典字母等级
+ClearCredits=清除游戏点数
+QuitGame=退出游戏
+
+[OptionExplanations]
+InfOptionsMain=Infinitesimal 主题相关的设置。
+InfOptionsUI=更改与用户界面相关的设置。
+InfOptionsGameplay=更改与游戏体验相关的设置。
+InfOptionsMisc=更改与主题相关的其他设置。
+
+BasicMode=使用对新手更容易的 Basic Mode。
+CenterChartList=如果谱面数量少于能被显示数量的最大值，谱面将被居中显示。
+ChartPreview=在选择歌曲界面预览所选择的谱面。
+ImagePreviewOnly=当选择歌曲的时候，视频不会在预览中播放。帮助改善在低端硬件上的性能以及内存使用情况。
+UseSelToPause=在游戏时使用 Select 按钮打开暂停菜单。（推荐安装了按钮电路板的私人机器拥有者使用）
+UseVideoBackground=使用预渲染的视频作为主题背景动画。需要重启游戏。（推荐配备好的 H.264 解码的硬件使用）
+EvalCenter3xExit=与正式游戏一样，按下中间面板三次以退出结果页面。否则按下一次就会退出。
+ShowBigBall=在选择难度时显示更大的图标。仅限宽高比大于 4:3 的情况。（推荐在当前显示距离过远或者难于看清难度时使用）
+ShowUCSCharts=允许选择 UCS 谱面。当一首歌曲没有标准谱面时，禁用此选项可能不会有用。
+ShowQuestCharts=允许选择 Quest 谱面。当一首歌曲没有标准谱面时，禁用此选项可能不会有用。
+ShowHiddenCharts=允许选择 Hidden 谱面。当一首歌曲没有标准谱面时，禁用此选项可能不会有用。
+AutogenBasicMode=允许游戏自动生成 Basic Mode 的歌曲列表。禁用此选项如果您想使用自己选择的列表。
+WrapChartScroll=当选择光标滚动至谱面列表的头或尾时，将其切换至另一边。
+StarField=在游戏时显示 K-Pump 原有的星空背景。
+ScoringSystem=选择使用的评分系统。新（Phoenix）或者旧（Fiesta - XX）。
+LifePositionBelow=当谱面滚动模式设置为 Reverse/DR 时将生命值条放置于判定区的下方。这也会改变个人资料名的放置位置。
+CarryJudgment=当一局结束后不重置判定难度设置。只对 Home 模式有效。Pay/Free Play 模式总会重置为 Pump normal（NJ）。
+ClassicGrades=使用包含金色的 S 字母在内的经典风格的字母等级。
+ClearCredits=清除投入的额外的游戏点数。
+QuitGame=退出游戏程式。方便街机操作员使用多重启动（multiboot）功能。
+
+[OptionNames]
+OffsetBar=显示偏差值条
+# Measure counter information
+Div_4ths=4ths
+Div_8ths=8ths
+Div_12ths=12ths
+Div_16ths=16ths
+Div_24ths=24ths
+Div_32nds=32nds
+
+AutoVelocityType=速度模式
+Multiply=Multiply
+Automatic=Automatic
+Constant=Constant
+
+AutoVelocity=速度值
+
+Noteskins=音符样式
+
+Filter=背景过滤
+FilterAmount=程度
+FilterColor=颜色
+DarkPlayerScreenFilter=Dark Player
+DarkScreenFilter=Black
+LightScreenFilter=White
+LightPlayerScreenFilter=Light Player
+GrayScreenFilter=Gray
+FilterSize=大小
+ScreenFilterFull=整个屏幕
+ScreenFilterLane=玩家区域
+
+Misc=其他
+Effects=效果
+Accel=速度特效
+Turn=Turn
+Scroll=移动方向
+Appearance=外观
+Modify=更改
+Persp=空间视角
+Rush=Rush
+50% Rate=Rush 50
+60% Rate=Rush 60
+70% Rate=Rush 70
+80% Rate=Rush 80
+90% Rate=Rush 90
+100% Rate=Rush 100
+110% Rate=Rush 110
+120% Rate=Rush 120
+150% Rate=Rush 150
+200% Rate=Rush 200
+X Mode=X Mode
+Vanish=Vanish
+Appear=Appear
+Non Step=Non Step
+Acceleration=Acceleration
+Deceleration=Deceleration
+Earthworm=Earthworm
+Random Speed=Random Speed
+Super Random=Super Random
+No Mines=No Mines
+No Holds=No Holds
+No Jumps=No Jumps
+No Hands=No Hands
+No Receptors=No Receptors
+No Judgement=No Judgement
+Size=箭头大小
+80% Size=80% Size
+90% Size=90% Size
+100% Size=100% Size
+110% Size=110% Size
+120% Size=120% Size
+Incoming=Incoming
+Space=Space
+Hallway=Hallway
+Distant=Distant
+
+System=系统
+TimingWindow=判定难度
+Judgement=判定字体
+JudgeItem=判定选项
+ProTiming=显示毫秒
+HideJudgment=隐藏判定
+ScoreDisplay=分数显示
+Score=分数
+Percent=百分比
+MeasureCount=Measures
+StreamOnly=Stream Only
+All=All
+MeasureDiv=Measures 类型
+SongProgress=歌曲进度
+ProLifebar=Pro Lifebar
+ResetOptions=Reset
+
+1x=1x
+2x=2x
+2.5x=2.5x
+3x=3x
+3.5x=3.5x
+4x=4x
+4.5x=4.5x
+5x=5x
+6x=6x
+8x=8x
+
+Old=旧
+New=新
+
+[ModIcons]
+-10% Mini=Arrow 110%
+-20% Mini=Arrow 120%
+0% Mini=Arrow 100%
+10% Mini=Arrow 90%
+20% Mini=Arrow 80%
+45% XMode=NX
+Alternate=AL
+Beat=BT
+Blind=HG
+Boost=AC
+Brake=DC
+Centered=CE
+Cross=CR
+Dark=FD
+Dizzy=DI
+Drunk=DRK
+Expand=EW
+Filter=BGA
+Hidden=V
+Mirror=M
+NoHands=No Hands
+NoHolds=No Holds
+NoJumps=No Jumps
+NoMines=No Mines
+RandomSpeed=SR
+Reverse=DR
+Rush=Rush
+Shuffle=RS
+Snake=SNK
+Stealth=NS
+Sudden=AP
+SuperShuffle=SRS
+Tipsy=TI
+Twirl=RG
+Incoming=Incoming
+Space=Space
+Hallway=Hallway
+Distant=Distant
+
+Original=SM
+ITG=ITG
+Pump Easy=EJ
+Pump Normal=NJ
+Pump Hard=HJ
+Pump Very Hard=VJ
+Infinity=INF
+Pro=PRO
+Jump=JUMP
+
+[Pump Easy]
+JudgmentW1=Perfect
+JudgmentW2=Great
+JudgmentW3=Good
+JudgmentW4=Bad
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Infinity]
+JudgmentW1=Superb
+JudgmentW2=Perfect
+JudgmentW3=Great
+JudgmentW4=Good
+JudgmentW5=Bad
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Pro]
+JudgmentW1=Superb
+JudgmentW2=Perfect
+JudgmentW3=Great
+JudgmentW4=Good
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Jump]
+JudgmentW1=Perfect
+JudgmentW2=Great
+JudgmentW3=Good
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[EvaluationLabel]
+Accuracy=Accuracy
+Score=Score
+
+[MessageBoxes]
+TutorialTitle=Using the Menu
+TutorialBody=使用 &DOWNLEFT; 和 &DOWNRIGHT; 选择歌曲。\n当您找到一首您想玩的歌曲时，\n使用 &CENTER; 选择它。\n然后选择一个难度。\n如果您改变您的主意了，使用 &UPLEFT; 或 &UPRIGHT; 后退以选择另一首歌曲。
+
+HowToPlayTitle1=The Basics
+HowToPlayTitle2=Freeze!
+HowToPlayTitle3=Be Careful
+
+HowToPlayBody1=主要目标是跟随音乐的节奏踩在箭头上。\n\n当移动的箭头与屏幕上方灰色的箭头目标\n重合时，踩上去！
+HowToPlayBody2=如果来了一个长箭头，一直踩住直到它的\n结尾！\n\n不要抬脚，否则您会错失歌曲的节拍！
+HowToPlayBody3=如果箭头移动超过了灰色的箭头目标，这将\n减少您的生命值条和分数。\n\n这对于长箭头尤其重要，因为它们可以在短\n时间内带来很多 misses！

--- a/Languages/zh-Hant.ini
+++ b/Languages/zh-Hant.ini
@@ -1,0 +1,287 @@
+[Common]
+WindowTitle=Infinitesimal
+
+[ScreenTitleMenu]
+GameStart=開始
+Edit/Share=編輯
+Profiles=個人資料
+ReportError=彙報 Bug
+%i Songs (%i Groups), %i Courses=%i 首歌曲（%i 專輯），%i 曲組
+
+[ProfileStats]
+No Profile=No Profile
+Level=Level
+
+[ChartInfo]
+By=by
+
+[BasicMode]
+NoSongs=Basic Mode 中沒有任何歌曲！\n請重新啓動遊戲或者添加更多歌曲。
+Double=DOUBLE
+Easy=EASY
+Normal=NORMAL
+Hard=HARD
+Very Hard=VERY HARD
+
+[OptionTitles]
+InfOptionsMain=Infinitesimal 設置
+InfOptionsUI=界面設置
+InfOptionsGameplay=遊戲設置
+InfOptionsMisc=其他設置
+
+BasicMode=Basic Mode
+CenterChartList=譜面列表居中
+ChartPreview=譜面預覽
+ImagePreviewOnly=僅使用圖片預覽
+UseSelToPause=使用 Select 按鈕暫停
+UseVideoBackground=使用視頻背景
+EvalCenter3xExit=按下中間面板三次\n以退出結果界面
+ShowBigBall=顯示大的難度圖標
+ShowUCSCharts=顯示 UCS 譜面
+ShowQuestCharts=顯示 Quest 譜面
+ShowHiddenCharts=顯示 Hidden 譜面
+AutogenBasicMode=自動生成 Basic Mode
+WrapChartScroll=譜面列表選擇切換
+StarField=星空背景
+ScoringSystem=評分系統
+LifePositionBelow=Reverse 生命值條下置
+CarryJudgment=延續判定設置
+ClassicGrades=經典字母等級
+ClearCredits=清除遊戲點數
+QuitGame=退出遊戲
+
+[OptionExplanations]
+InfOptionsMain=Infinitesimal 主題相關的設置。
+InfOptionsUI=更改與用戶界面相關的設置。
+InfOptionsGameplay=更改與遊戲體驗相關的設置。
+InfOptionsMisc=更改與主題相關的其他設置。
+
+BasicMode=使用對新手更容易的 Basic Mode。
+CenterChartList=如果譜面數量少於能被顯示數量的最大值，譜面將被居中顯示。
+ChartPreview=在選擇歌曲界面預覽所選擇的譜面。
+ImagePreviewOnly=當選擇歌曲的時候，視頻不會在預覽中播放。幫助改善在低端硬件上的性能以及內存使用情況。
+UseSelToPause=在遊戲時使用 Select 按鈕打開暫停菜單。（推薦安裝了按鈕電路板的私人機器擁有者使用）
+UseVideoBackground=使用預渲染的視頻作爲主題背景動畫。需要重啓遊戲。（推薦配備好的 H.264 解碼的硬件使用）
+EvalCenter3xExit=與正式遊戲一樣，按下中間面板三次以退出結果頁面。否則按下一次就會退出。
+ShowBigBall=在選擇難度時顯示更大的圖標。僅限寬高比大於 4:3 的情況。（推薦在當前顯示距離過遠或者難於看清難度時使用）
+ShowUCSCharts=允許選擇 UCS 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
+ShowQuestCharts=允許選擇 Quest 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
+ShowHiddenCharts=允許選擇 Hidden 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
+AutogenBasicMode=允許遊戲自動生成 Basic Mode 的歌曲列表。禁用此選項如果您想使用自己選擇的列表。
+WrapChartScroll=當選擇光標滾動至譜面列表的頭或尾時，將其切換至另一邊。
+StarField=在遊戲時顯示 K-Pump 原有的星空背景。
+ScoringSystem=選擇使用的評分系統。新（Phoenix）或者舊（Fiesta - XX）。
+LifePositionBelow=當譜面滾動模式設置爲 Reverse/DR 時將生命值條放置於判定區的下方。這也會改變個人資料名的放置位置。
+CarryJudgment=當一局結束後不重置判定難度設置。只對 Home 模式有效。Pay/Free Play 模式總會重置爲 Pump normal（NJ）。
+ClassicGrades=使用包含金色的 S 字母在內的經典風格的字母等級。
+ClearCredits=清除投入的額外的遊戲點數。
+QuitGame=退出遊戲程式。方便街機操作員使用多重啓動（multiboot）功能。
+
+[OptionNames]
+OffsetBar=顯示偏差值條
+# Measure counter information
+Div_4ths=4ths
+Div_8ths=8ths
+Div_12ths=12ths
+Div_16ths=16ths
+Div_24ths=24ths
+Div_32nds=32nds
+
+AutoVelocityType=速度模式
+Multiply=Multiply
+Automatic=Automatic
+Constant=Constant
+
+AutoVelocity=速度值
+
+Noteskins=音符樣式
+
+Filter=背景過濾
+FilterAmount=程度
+FilterColor=顏色
+DarkPlayerScreenFilter=Dark Player
+DarkScreenFilter=Black
+LightScreenFilter=White
+LightPlayerScreenFilter=Light Player
+GrayScreenFilter=Gray
+FilterSize=大小
+ScreenFilterFull=整個屏幕
+ScreenFilterLane=玩家區域
+
+Misc=其他
+Effects=效果
+Accel=速度特效
+Turn=Turn
+Scroll=移動方向
+Appearance=外觀
+Modify=更改
+Persp=空間視角
+Rush=Rush
+50% Rate=Rush 50
+60% Rate=Rush 60
+70% Rate=Rush 70
+80% Rate=Rush 80
+90% Rate=Rush 90
+100% Rate=Rush 100
+110% Rate=Rush 110
+120% Rate=Rush 120
+150% Rate=Rush 150
+200% Rate=Rush 200
+X Mode=X Mode
+Vanish=Vanish
+Appear=Appear
+Non Step=Non Step
+Acceleration=Acceleration
+Deceleration=Deceleration
+Earthworm=Earthworm
+Random Speed=Random Speed
+Super Random=Super Random
+No Mines=No Mines
+No Holds=No Holds
+No Jumps=No Jumps
+No Hands=No Hands
+No Receptors=No Receptors
+No Judgement=No Judgement
+Size=箭頭大小
+80% Size=80% Size
+90% Size=90% Size
+100% Size=100% Size
+110% Size=110% Size
+120% Size=120% Size
+Incoming=Incoming
+Space=Space
+Hallway=Hallway
+Distant=Distant
+
+System=系統
+TimingWindow=判定難度
+Judgement=判定字體
+JudgeItem=判定選項
+ProTiming=顯示毫秒
+HideJudgment=隱藏判定
+ScoreDisplay=分數顯示
+Score=分數
+Percent=百分比
+MeasureCount=Measures
+StreamOnly=Stream Only
+All=All
+MeasureDiv=Measures 類型
+SongProgress=歌曲進度
+ProLifebar=Pro Lifebar
+ResetOptions=Reset
+
+1x=1x
+2x=2x
+2.5x=2.5x
+3x=3x
+3.5x=3.5x
+4x=4x
+4.5x=4.5x
+5x=5x
+6x=6x
+8x=8x
+
+Old=舊
+New=新
+
+[ModIcons]
+-10% Mini=Arrow 110%
+-20% Mini=Arrow 120%
+0% Mini=Arrow 100%
+10% Mini=Arrow 90%
+20% Mini=Arrow 80%
+45% XMode=NX
+Alternate=AL
+Beat=BT
+Blind=HG
+Boost=AC
+Brake=DC
+Centered=CE
+Cross=CR
+Dark=FD
+Dizzy=DI
+Drunk=DRK
+Expand=EW
+Filter=BGA
+Hidden=V
+Mirror=M
+NoHands=No Hands
+NoHolds=No Holds
+NoJumps=No Jumps
+NoMines=No Mines
+RandomSpeed=SR
+Reverse=DR
+Rush=Rush
+Shuffle=RS
+Snake=SNK
+Stealth=NS
+Sudden=AP
+SuperShuffle=SRS
+Tipsy=TI
+Twirl=RG
+Incoming=Incoming
+Space=Space
+Hallway=Hallway
+Distant=Distant
+
+Original=SM
+ITG=ITG
+Pump Easy=EJ
+Pump Normal=NJ
+Pump Hard=HJ
+Pump Very Hard=VJ
+Infinity=INF
+Pro=PRO
+Jump=JUMP
+
+[Pump Easy]
+JudgmentW1=Perfect
+JudgmentW2=Great
+JudgmentW3=Good
+JudgmentW4=Bad
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Infinity]
+JudgmentW1=Superb
+JudgmentW2=Perfect
+JudgmentW3=Great
+JudgmentW4=Good
+JudgmentW5=Bad
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Pro]
+JudgmentW1=Superb
+JudgmentW2=Perfect
+JudgmentW3=Great
+JudgmentW4=Good
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[Jump]
+JudgmentW1=Perfect
+JudgmentW2=Great
+JudgmentW3=Good
+JudgmentHeld=Held
+JudgmentMaxCombo=Max Combo
+JudgmentMiss=Miss
+
+[EvaluationLabel]
+Accuracy=Accuracy
+Score=Score
+
+[MessageBoxes]
+TutorialTitle=Using the Menu
+TutorialBody=使用 &DOWNLEFT; 和 &DOWNRIGHT; 選擇歌曲。\n當您找到一首您想玩的歌曲時，\n使用 &CENTER; 選擇它。\n然後選擇一個難度。\n如果您改變您的主意了，使用 &UPLEFT; 或 &UPRIGHT; 後退以選擇另一首歌曲。
+
+HowToPlayTitle1=The Basics
+HowToPlayTitle2=Freeze!
+HowToPlayTitle3=Be Careful
+
+HowToPlayBody1=主要目標是跟隨音樂的節奏踩在箭頭上。\n\n當移動的箭頭與屏幕上方灰色的箭頭目標\n重合時，踩上去！
+HowToPlayBody2=如果來了一個長箭頭，一直踩住直到它的\n結尾！\n\n不要抬腳，否則您會錯失歌曲的節拍！
+HowToPlayBody3=如果箭頭移動超過了灰色的箭頭目標，這將\n減少您的生命值條和分數。\n\n這對於長箭頭尤其重要，因爲它們可以在短\n時間內帶來很多 misses！

--- a/Languages/zh-Hant.ini
+++ b/Languages/zh-Hant.ini
@@ -16,7 +16,7 @@ Level=Level
 By=by
 
 [BasicMode]
-NoSongs=Basic Mode 中沒有任何歌曲！\n請重新啓動遊戲或者添加更多歌曲。
+NoSongs=Basic Mode 中沒有任何歌曲！\n請重新啟動遊戲或者新增更多歌曲。
 Double=DOUBLE
 Easy=EASY
 Normal=NORMAL
@@ -24,19 +24,19 @@ Hard=HARD
 Very Hard=VERY HARD
 
 [OptionTitles]
-InfOptionsMain=Infinitesimal 設置
-InfOptionsUI=界面設置
-InfOptionsGameplay=遊戲設置
-InfOptionsMisc=其他設置
+InfOptionsMain=Infinitesimal 設定
+InfOptionsUI=介面設定
+InfOptionsGameplay=遊戲設定
+InfOptionsMisc=其他設定
 
 BasicMode=Basic Mode
 CenterChartList=譜面列表居中
 ChartPreview=譜面預覽
 ImagePreviewOnly=僅使用圖片預覽
 UseSelToPause=使用 Select 按鈕暫停
-UseVideoBackground=使用視頻背景
-EvalCenter3xExit=按下中間面板三次\n以退出結果界面
-ShowBigBall=顯示大的難度圖標
+UseVideoBackground=使用影片背景
+EvalCenter3xExit=按下中間面板三次\n以退出結果介面
+ShowBigBall=顯示大的難度圖示
 ShowUCSCharts=顯示 UCS 譜面
 ShowQuestCharts=顯示 Quest 譜面
 ShowHiddenCharts=顯示 Hidden 譜面
@@ -45,37 +45,37 @@ WrapChartScroll=譜面列表選擇切換
 StarField=星空背景
 ScoringSystem=評分系統
 LifePositionBelow=Reverse 生命值條下置
-CarryJudgment=延續判定設置
+CarryJudgment=延續判定設定
 ClassicGrades=經典字母等級
 ClearCredits=清除遊戲點數
 QuitGame=退出遊戲
 
 [OptionExplanations]
-InfOptionsMain=Infinitesimal 主題相關的設置。
-InfOptionsUI=更改與用戶界面相關的設置。
-InfOptionsGameplay=更改與遊戲體驗相關的設置。
-InfOptionsMisc=更改與主題相關的其他設置。
+InfOptionsMain=Infinitesimal 主題相關的設定。
+InfOptionsUI=更改與使用者介面相關的設定。
+InfOptionsGameplay=更改與遊戲體驗相關的設定。
+InfOptionsMisc=更改與主題相關的其他設定。
 
 BasicMode=使用對新手更容易的 Basic Mode。
 CenterChartList=如果譜面數量少於能被顯示數量的最大值，譜面將被居中顯示。
-ChartPreview=在選擇歌曲界面預覽所選擇的譜面。
-ImagePreviewOnly=當選擇歌曲的時候，視頻不會在預覽中播放。幫助改善在低端硬件上的性能以及內存使用情況。
-UseSelToPause=在遊戲時使用 Select 按鈕打開暫停菜單。（推薦安裝了按鈕電路板的私人機器擁有者使用）
-UseVideoBackground=使用預渲染的視頻作爲主題背景動畫。需要重啓遊戲。（推薦配備好的 H.264 解碼的硬件使用）
+ChartPreview=在選擇歌曲介面預覽所選擇的譜面。
+ImagePreviewOnly=當選擇歌曲的時候，影片不會在預覽中播放。幫助改善在低端硬體上的效能以及記憶體使用情況。
+UseSelToPause=在遊戲時使用 Select 按鈕開啟暫停選單。（推薦安裝了按鈕電路板的私人機器擁有者使用）
+UseVideoBackground=使用預渲染的影片作為主題背景動畫。需要重啟遊戲。（推薦配備好的 H.264 解碼的硬體使用）
 EvalCenter3xExit=與正式遊戲一樣，按下中間面板三次以退出結果頁面。否則按下一次就會退出。
-ShowBigBall=在選擇難度時顯示更大的圖標。僅限寬高比大於 4:3 的情況。（推薦在當前顯示距離過遠或者難於看清難度時使用）
+ShowBigBall=在選擇難度時顯示更大的圖示。僅限寬高比大於 4:3 的情況。（推薦在當前顯示距離過遠或者難於看清難度時使用）
 ShowUCSCharts=允許選擇 UCS 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
 ShowQuestCharts=允許選擇 Quest 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
 ShowHiddenCharts=允許選擇 Hidden 譜面。當一首歌曲沒有標準譜面時，禁用此選項可能不會有用。
 AutogenBasicMode=允許遊戲自動生成 Basic Mode 的歌曲列表。禁用此選項如果您想使用自己選擇的列表。
-WrapChartScroll=當選擇光標滾動至譜面列表的頭或尾時，將其切換至另一邊。
+WrapChartScroll=當選擇游標滾動至譜面列表的頭或尾時，將其切換至另一邊。
 StarField=在遊戲時顯示 K-Pump 原有的星空背景。
 ScoringSystem=選擇使用的評分系統。新（Phoenix）或者舊（Fiesta - XX）。
-LifePositionBelow=當譜面滾動模式設置爲 Reverse/DR 時將生命值條放置於判定區的下方。這也會改變個人資料名的放置位置。
-CarryJudgment=當一局結束後不重置判定難度設置。只對 Home 模式有效。Pay/Free Play 模式總會重置爲 Pump normal（NJ）。
+LifePositionBelow=當譜面滾動模式設定為 Reverse/DR 時將生命值條放置於判定區的下方。這也會改變個人資料名的放置位置。
+CarryJudgment=當一局結束後不重置判定難度設定。只對 Home 模式有效。Pay/Free Play 模式總會重置為 Pump normal（NJ）。
 ClassicGrades=使用包含金色的 S 字母在內的經典風格的字母等級。
 ClearCredits=清除投入的額外的遊戲點數。
-QuitGame=退出遊戲程式。方便街機操作員使用多重啓動（multiboot）功能。
+QuitGame=退出遊戲程式。方便街機操作員使用多重啟動（multiboot）功能。
 
 [OptionNames]
 OffsetBar=顯示偏差值條
@@ -105,7 +105,7 @@ LightScreenFilter=White
 LightPlayerScreenFilter=Light Player
 GrayScreenFilter=Gray
 FilterSize=大小
-ScreenFilterFull=整個屏幕
+ScreenFilterFull=整個螢幕
 ScreenFilterLane=玩家區域
 
 Misc=其他
@@ -155,7 +155,7 @@ Distant=Distant
 
 System=系統
 TimingWindow=判定難度
-Judgement=判定字體
+Judgement=判定字型
 JudgeItem=判定選項
 ProTiming=顯示毫秒
 HideJudgment=隱藏判定
@@ -165,7 +165,7 @@ Percent=百分比
 MeasureCount=Measures
 StreamOnly=Stream Only
 All=All
-MeasureDiv=Measures 類型
+MeasureDiv=Measures 型別
 SongProgress=歌曲進度
 ProLifebar=Pro Lifebar
 ResetOptions=Reset
@@ -282,6 +282,6 @@ HowToPlayTitle1=The Basics
 HowToPlayTitle2=Freeze!
 HowToPlayTitle3=Be Careful
 
-HowToPlayBody1=主要目標是跟隨音樂的節奏踩在箭頭上。\n\n當移動的箭頭與屏幕上方灰色的箭頭目標\n重合時，踩上去！
+HowToPlayBody1=主要目標是跟隨音樂的節奏踩在箭頭上。\n\n當移動的箭頭與螢幕上方灰色的箭頭目標\n重合時，踩上去！
 HowToPlayBody2=如果來了一個長箭頭，一直踩住直到它的\n結尾！\n\n不要抬腳，否則您會錯失歌曲的節拍！
-HowToPlayBody3=如果箭頭移動超過了灰色的箭頭目標，這將\n減少您的生命值條和分數。\n\n這對於長箭頭尤其重要，因爲它們可以在短\n時間內帶來很多 misses！
+HowToPlayBody3=如果箭頭移動超過了灰色的箭頭目標，這將\n減少您的生命值條和分數。\n\n這對於長箭頭尤其重要，因為它們可以在短\n時間內帶來很多 misses！


### PR DESCRIPTION
I have frequently referenced the [OutFox-zh-CN](https://github.com/Tiny-Foxes/OutFox-zh-CN) project and tried to use the same translations as much as I can. 

The Traditional Chinese version is converted from the Simplified Chinese version using [OpenCC](https://github.com/BYVoid/OpenCC) with the config ([s2twp.json](https://github.com/BYVoid/OpenCC/blob/master/data/config/s2twp.json)) with phrase conversion in Taiwan standard.