### PR TITLE
Fix 000 judgement count showing all 0s grayed out

### DIFF
--- a/BGAnimations/ScreenEvaluation underlay/EvalLines.lua
+++ b/BGAnimations/ScreenEvaluation underlay/EvalLines.lua
@@ -189,11 +189,7 @@ for i = 1, RowAmount do
                 self:x(-RowX):shadowlength(1):zoom(0.8)
                 :halign(0):maxwidth(360):visible(GAMESTATE:IsSideJoined(PLAYER_1))
 				if Name[i] ~= "Score" and Name[i] ~= "Accuracy" then
-					if GetJLineValue(Name[i], PLAYER_1) > 0 then
-						self:AddAttribute(0, { Length = 3-string.len(GetJLineValue(Name[i], PLAYER_1)) ; Diffuse = color("#FFFFFF88"); })
-					else
-						self:AddAttribute(0, { Length = 3 ; Diffuse = color("#FFFFFF88"); })
-					end
+					self:AddAttribute(0, { Length = 3-string.len(GetJLineValue(Name[i], PLAYER_1)) ; Diffuse = color("#FFFFFF88"); })
                 end
 				if Name[i] == "Score" then
                     ColourHighScoreCount(self)
@@ -208,11 +204,7 @@ for i = 1, RowAmount do
                 self:x(RowX):shadowlength(1):zoom(0.8)
                 :halign(1):maxwidth(360):visible(GAMESTATE:IsSideJoined(PLAYER_2))
                 if Name[i] ~= "Score" and Name[i] ~= "Accuracy" then
-					if GetJLineValue(Name[i], PLAYER_2) > 0 then
 						self:AddAttribute(0, { Length = 3-string.len(GetJLineValue(Name[i], PLAYER_2)) ; Diffuse = color("#FFFFFF88"); })
-					else
-						self:AddAttribute(0, { Length = 3 ; Diffuse = color("#FFFFFF88"); })
-					end
                 end
 				if Name[i] == "Score" then
                     ColourHighScoreCount(self)


### PR DESCRIPTION
Minor consistency fix. Inspired by how infinity does it: when one of the judgements is 0, the last digit 0 will be regular coloured, while the other two zeroes will be considered leading zeroes and grayed out.